### PR TITLE
OnTriggerXXX で NullReferenceException が発生する問題を改修

### DIFF
--- a/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
+++ b/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
@@ -1003,7 +1003,7 @@ public static class Library_SpriteStudio
 
 		void OnTriggerEnter(Collider Pair)
 		{
-			if(null == functionOnTriggerEnter)
+			if(null != functionOnTriggerEnter)
 			{
 				functionOnTriggerEnter(collider, Pair);
 			}
@@ -1011,7 +1011,7 @@ public static class Library_SpriteStudio
 
 		void OnTriggerExit(Collider Pair)
 		{
-			if(null == functionOnTriggerEnd)
+			if(null != functionOnTriggerEnd)
 			{
 				functionOnTriggerEnter(collider, Pair);
 			}
@@ -1019,7 +1019,7 @@ public static class Library_SpriteStudio
 
 		void OnTriggerStay(Collider Pair)
 		{
-			if(null == functionOnTriggerStay)
+			if(null != functionOnTriggerStay)
 			{
 				functionOnTriggerStay(collider, Pair);
 			}
@@ -1027,7 +1027,7 @@ public static class Library_SpriteStudio
 
 		void OnCollisionEnter(Collision Contacts)
 		{
-			if(null == functionOnCollisionEnter)
+			if(null != functionOnCollisionEnter)
 			{
 				functionOnCollisionEnter(collider, Contacts);
 			}
@@ -1035,7 +1035,7 @@ public static class Library_SpriteStudio
 
 		void OnCollisionExit(Collision Contacts)
 		{
-			if(null == functionOnCollisionEnd)
+			if(null != functionOnCollisionEnd)
 			{
 				functionOnCollisionEnd(collider, Contacts);
 			}
@@ -1043,7 +1043,7 @@ public static class Library_SpriteStudio
 
 		void OnCollisionStay(Collision Contacts)
 		{
-			if(null == functionOnCollisionStay)
+			if(null != functionOnCollisionStay)
 			{
 				functionOnCollisionStay(collider, Contacts);
 			}


### PR DESCRIPTION
# Issue
- Collider の各種イベント処理 (OnTriggerXXX) にまつわる delegate について、設定有無を問わず NullReferenceException が発生する
- Collider を設定していない場合は、そもそも OnTriggerXXX が呼び出されないため発生しない
# Fix
- OnTriggerXXX メソッドに於ける delegate の判定処理が真偽逆転しているため、不等号を反転させた
# Note
- リポジトリ運用ルールが分かりかねましたので、いきなり PullRequest を作成してしまいました…。
- 先行して Issue を切った方がよろしい場合は、今後そのようにいたします。
