### PR TITLE
AnimationDataCell の要素数の検証処理が漏れていたのを修正

### DIFF
--- a/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
+++ b/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
@@ -1816,20 +1816,17 @@ public static class Library_SpriteStudio
 			Rect RectCell = Rect.MinMaxRect(0.0f, 0.0f, 64.0f, 64.0f);
 			int	VertexCollectionIndexTableNo = 0;
 
-			/* Main-Texture Data Get */
 			if(0 < AnimationDataCell.Length)
 			{
+				/* Main-Texture Data Get */
 				Material MaterialNow = ScriptRoot.MaterialGet(AnimationDataCell[FrameNo].DataBody.TextureNo, KindBlendTarget);
 				if(null != MaterialNow)
 				{
 					SizeTexture.x = AnimationDataCell[FrameNo].DataBody.SizeOriginal.x;
 					SizeTexture.y = AnimationDataCell[FrameNo].DataBody.SizeOriginal.y;
 				}
-			}
 
 			/* Cell-Data Get */
-			if(0 < AnimationDataCell.Length)
-			{
 				RectCell = AnimationDataCell[FrameNo].DataBody.Rectangle;
 				PivotTexture = new Vector2(RectCell.width * 0.5f, RectCell.height * 0.5f);
 

--- a/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
+++ b/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
@@ -1817,11 +1817,14 @@ public static class Library_SpriteStudio
 			int	VertexCollectionIndexTableNo = 0;
 
 			/* Main-Texture Data Get */
-			Material MaterialNow = ScriptRoot.MaterialGet(AnimationDataCell[FrameNo].DataBody.TextureNo, KindBlendTarget);
-			if(null != MaterialNow)
+			if(0 < AnimationDataCell.Length)
 			{
-				SizeTexture.x = AnimationDataCell[FrameNo].DataBody.SizeOriginal.x;
-				SizeTexture.y = AnimationDataCell[FrameNo].DataBody.SizeOriginal.y;
+				Material MaterialNow = ScriptRoot.MaterialGet(AnimationDataCell[FrameNo].DataBody.TextureNo, KindBlendTarget);
+				if(null != MaterialNow)
+				{
+					SizeTexture.x = AnimationDataCell[FrameNo].DataBody.SizeOriginal.x;
+					SizeTexture.y = AnimationDataCell[FrameNo].DataBody.SizeOriginal.y;
+				}
 			}
 
 			/* Cell-Data Get */


### PR DESCRIPTION
# 問題
* `Main-Texture Data Get` の箇所で、`AnimationDataCell` から `FrameNo` の位置のデータの取り出しを行っているが、`AnimationDataCell` が空配列である場合に `Out of Index` のエラーとなる。

# 解決
* `Cell-Data Get` の箇所でやっているのと同様に、要素数が0の場合は処理を行わないように変更しました。
* 同じ検証が２回行われることになるので、`if` 文をまとめました。