### PR TITLE
iPhoneやAndroidでLinkPrefabをDestroyしないように。

### DIFF
--- a/Assets/SpriteStudio/Script/Script_SpriteStudio_LinkPrefab.cs
+++ b/Assets/SpriteStudio/Script/Script_SpriteStudio_LinkPrefab.cs
@@ -37,7 +37,8 @@ public class Script_SpriteStudio_LinkPrefab : MonoBehaviour
 		}
 #else
 		PrefabLinkInstantiate();
-		PrefabLinkDeleteScript();
+		// You should not delete link prefab class. I can't change prefab if deleted.
+		//PrefabLinkDeleteScript();
 #endif
 	}
 


### PR DESCRIPTION
実機でパーツ切り替えを行う時に無いと不便