### PR TITLE
孫以降のインスタンスのアニメーション開始フレームが遅れるのを修正

### DIFF
--- a/Assets/SpriteStudio/Script/Script_SpriteStudio_DrawManagerView.cs
+++ b/Assets/SpriteStudio/Script/Script_SpriteStudio_DrawManagerView.cs
@@ -25,7 +25,6 @@ public class Script_SpriteStudio_DrawManagerView : MonoBehaviour
 	public Library_SpriteStudio.DrawManager.KindDrawQueue KindRenderQueueBase;
 	public int OffsetDrawQueue;
 
-	private Camera InstanceCameraDraw;
 #if false
 	/* MEMO: Non-Generic List-Class */
 	private ArrayList DrawEntryPartsRoot;
@@ -44,7 +43,6 @@ public class Script_SpriteStudio_DrawManagerView : MonoBehaviour
 	/* Functions */
 	void Start()
 	{
-		InstanceCameraDraw = Library_SpriteStudio.Utility.CameraGetParent(gameObject);
 
 #if false
 		/* MEMO: Non-Generic List-Class */
@@ -63,10 +61,6 @@ public class Script_SpriteStudio_DrawManagerView : MonoBehaviour
 	void Update()
 	{
 		/* Boot-Check */
-		if(null == InstanceCameraDraw)
-		{
-			InstanceCameraDraw = Library_SpriteStudio.Utility.CameraGetParent(gameObject);
-		}
 		if(null == DrawEntryPartsRoot)
 		{
 #if false
@@ -217,7 +211,7 @@ public class Script_SpriteStudio_DrawManagerView : MonoBehaviour
 		/* Meshes Combine each Material & Set to MeshFilter/MeshRenderer */
 		MeshFilter InstanceMeshFilter = GetComponent<MeshFilter>();
 		MeshRenderer InstanceMeshRenderer = GetComponent<MeshRenderer>();
-		arrayListMeshDraw.MeshSetCombine(InstanceMeshFilter, InstanceMeshRenderer, InstanceCameraDraw, transform);
+		arrayListMeshDraw.MeshSetCombine(InstanceMeshFilter, InstanceMeshRenderer, transform);
 	}
 
 	internal void DrawEntryObject(Script_SpriteStudio_PartsRoot PartsRootDrawObject)

--- a/Assets/SpriteStudio/Script/Script_SpriteStudio_PartsRoot.cs
+++ b/Assets/SpriteStudio/Script/Script_SpriteStudio_PartsRoot.cs
@@ -406,7 +406,6 @@ public class Script_SpriteStudio_PartsRoot : Library_SpriteStudio.PartsBase
 		}
 	}
 
-	private Camera InstanceCameraDraw;
 	private Script_SpriteStudio_DrawManagerView InstanceDrawManagerView;
 	private GameObject InstanceGameObjectControl = null;
 	private Script_SpriteStudio_PartsRoot partsRootOrigin = null;
@@ -436,7 +435,6 @@ public class Script_SpriteStudio_PartsRoot : Library_SpriteStudio.PartsBase
 
 	void Start()
 	{
-		InstanceCameraDraw = Library_SpriteStudio.Utility.CameraGetParent(gameObject);
 		InstanceDrawManagerView = Library_SpriteStudio.Utility.DrawManagerViewGetParent(gameObject);
 		rateOpacity = 1.0f;
 
@@ -483,10 +481,6 @@ public class Script_SpriteStudio_PartsRoot : Library_SpriteStudio.PartsBase
 		}
 
 		/* Boot-Check */
-		if(null == InstanceCameraDraw)
-		{
-			InstanceCameraDraw = Library_SpriteStudio.Utility.CameraGetParent(gameObject);
-		}
 		if(null == InstanceDrawManagerView)
 		{
 			InstanceDrawManagerView = Library_SpriteStudio.Utility.DrawManagerViewGetParent(gameObject);

--- a/Assets/SpriteStudio/Script/Script_SpriteStudio_PartsRoot.cs
+++ b/Assets/SpriteStudio/Script/Script_SpriteStudio_PartsRoot.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 public class Script_SpriteStudio_PartsRoot : Library_SpriteStudio.PartsBase
 {
 	/* Constants */
+	[System.Flags]
 	public enum BitStatus
 	{
 		PLAYING = 0x800000,
@@ -28,7 +29,8 @@ public class Script_SpriteStudio_PartsRoot : Library_SpriteStudio.PartsBase
 		REDECODE_INSTANCE = 0x002000,
 
 		CLEAR = 0x000000,
-		MASK_INITIAL = (PLAYING | PAUSING | STYLE_REVERSE | PLAYING_REVERSE | PLAY_FIRST | REQUEST_PLAYEND | DECODE_USERDATA),
+		MASK_INITIAL = (PLAYING | PAUSING | STYLE_REVERSE | PLAYING_REVERSE | PLAY_FIRST | REQUEST_PLAYEND | DECODE_USERDATA | REDECODE_INSTANCE),
+		INITIAL = ~MASK_INITIAL,
 	};
 	public enum PlayStyle
 	{

--- a/Assets/SpriteStudio/Script/SpriteStudioExtensions.cs
+++ b/Assets/SpriteStudio/Script/SpriteStudioExtensions.cs
@@ -1,0 +1,26 @@
+﻿/**
+	SpriteStudio5 Player for Unity
+
+	Copyright(C) Web Technology Corp. 
+	All rights reserved.
+*/
+using UnityEngine;
+
+/// <summary>
+/// SpriteStudio用の拡張メソッド。
+/// </summary>
+public static class SpriteStudioExtensions
+{
+    /// <summary>
+    /// 表示優先順位を取得する。
+    /// </summary>
+    /// <param name="root"></param>
+    /// <returns></returns>
+    public static float GetDisplayOrder(this Script_SpriteStudio_PartsRoot root)
+    {
+        Matrix4x4 MatrixWorld = root.transform.localToWorldMatrix;
+        Vector3 OriginWorld = MatrixWorld.MultiplyPoint3x4(Vector3.zero);
+
+        return OriginWorld.z;
+    }
+}

--- a/Assets/SpriteStudio/Script/SpriteStudioExtensions.cs
+++ b/Assets/SpriteStudio/Script/SpriteStudioExtensions.cs
@@ -23,4 +23,32 @@ public static class SpriteStudioExtensions
 
         return OriginWorld.z;
     }
+
+    /// <summary>
+    /// 親をたどって<see cref="Script_SpriteStudio_PartsRoot.BitStatus.REDECODE_INSTANCE"/>がtrueになっているかどうかをチェックする。
+    /// 再帰的にたどることで孫以降の<see cref="Script_SpriteStudio_PartsInstance"/>のフレーム遅延問題を起きないようにする。
+    /// </summary>
+    /// <param name="root"></param>
+    /// <returns></returns>
+    public static bool CheckRedecodeInstanceInParent(this Script_SpriteStudio_PartsRoot root)
+    {
+        if (0 != (root.Status & Script_SpriteStudio_PartsRoot.BitStatus.REDECODE_INSTANCE))
+            return true;
+
+        var parentInstance = root.transform.parent.GetComponent<Script_SpriteStudio_PartsInstance>();
+        if (parentInstance == null)
+            return false;
+
+        return parentInstance.ScriptRoot.CheckRedecodeInstanceInParent();
+    }
+
+    /// <summary>
+    /// アニメーションの再生開始フレームかどうか。
+    /// </summary>
+    /// <param name="root"></param>
+    /// <returns></returns>
+    public static bool IsFirstPlay(this Script_SpriteStudio_PartsRoot root)
+    {
+        return root.FrameNoPrevious == root.FrameNoStart;
+    }
 }

--- a/Assets/SpriteStudio/Script/SpriteStudioExtensions.cs.meta
+++ b/Assets/SpriteStudio/Script/SpriteStudioExtensions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: feb16514ae3c84040a8e748f1ec25969
+timeCreated: 1437620621
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
+++ b/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
@@ -1597,7 +1597,8 @@ public static partial class Library_SpriteStudio
 				if(0 != (ScriptRoot.Status & Script_SpriteStudio_PartsRoot.BitStatus.DECODE_USERDATA))
 				{
 					int LoopCount = ScriptRoot.CountLoopThisTime;
-					bool FlagFirst = (0 != (ScriptRoot.Status & Script_SpriteStudio_PartsRoot.BitStatus.PLAY_FIRST)) ? true : false;
+					//bool FlagFirst = (0 != (ScriptRoot.Status & Script_SpriteStudio_PartsRoot.BitStatus.PLAY_FIRST)) ? true : false;
+					var FlagFirst = ScriptRoot.IsFirstPlay();
 					bool FlagReverse = (0 != (ScriptRoot.Status & Script_SpriteStudio_PartsRoot.BitStatus.PLAYING_REVERSE)) ? true : false;
 					bool FlagReversePrevious = ScriptRoot.FlagReversePrevious;
 					int FrameNoPrevious = (true == FlagFirst) ? ScriptRoot.FrameNoStart : (ScriptRoot.FrameNoPrevious + ((true == FlagReverse) ? -1 : 1));
@@ -1858,7 +1859,7 @@ public static partial class Library_SpriteStudio
 
 		UpdateInstanceData_PlayCommand_Force:;
 			{
-				if(0 != (ScriptRoot.Status & Script_SpriteStudio_PartsRoot.BitStatus.REDECODE_INSTANCE))
+				if (ScriptRoot.CheckRedecodeInstanceInParent())
 				{
 					PartsInstance.FrameNoPreviousUpdate = -1;
 				}
@@ -1897,6 +1898,8 @@ public static partial class Library_SpriteStudio
 													DataBody.LabelEnd,
 													DataBody.OffsetEnd
 												);
+				ScriptPartsRootSub.Status |= Script_SpriteStudio_PartsRoot.BitStatus.DECODE_USERDATA;
+				ScriptPartsRootSub.Status &= ~Script_SpriteStudio_PartsRoot.BitStatus.PLAY_FIRST;
 
 				int FrameCount = FrameNo - FrameNoInstanceBase;
 				FrameCount = (0 > FrameCount) ? 0 : FrameCount;
@@ -2758,7 +2761,7 @@ public static partial class Library_SpriteStudio
 		{
 			if(null != functionOnTriggerEnter)
 			{
-				functionOnTriggerEnter(collider, Pair);
+				functionOnTriggerEnter(GetComponent<Collider>(), Pair);
 			}
 		}
 
@@ -2766,7 +2769,7 @@ public static partial class Library_SpriteStudio
 		{
 			if(null != functionOnTriggerEnd)
 			{
-				functionOnTriggerEnter(collider, Pair);
+				functionOnTriggerEnter(GetComponent<Collider>(), Pair);
 			}
 		}
 
@@ -2774,7 +2777,7 @@ public static partial class Library_SpriteStudio
 		{
 			if(null != functionOnTriggerStay)
 			{
-				functionOnTriggerStay(collider, Pair);
+				functionOnTriggerStay(GetComponent<Collider>(), Pair);
 			}
 		}
 
@@ -2782,7 +2785,7 @@ public static partial class Library_SpriteStudio
 		{
 			if(null != functionOnCollisionEnter)
 			{
-				functionOnCollisionEnter(collider, Contacts);
+				functionOnCollisionEnter(GetComponent<Collider>(), Contacts);
 			}
 		}
 
@@ -2790,7 +2793,7 @@ public static partial class Library_SpriteStudio
 		{
 			if(null != functionOnCollisionEnd)
 			{
-				functionOnCollisionEnd(collider, Contacts);
+				functionOnCollisionEnd(GetComponent<Collider>(), Contacts);
 			}
 		}
 
@@ -2798,7 +2801,7 @@ public static partial class Library_SpriteStudio
 		{
 			if(null != functionOnCollisionStay)
 			{
-				functionOnCollisionStay(collider, Contacts);
+				functionOnCollisionStay(GetComponent<Collider>(), Contacts);
 			}
 		}
 	}

--- a/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
+++ b/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
@@ -230,22 +230,6 @@ public static partial class Library_SpriteStudio
 			return(DataSpriteStudio);
 		}
 
-		public static Camera CameraGetParent(GameObject InstanceGameObject)
-		{
-			Transform InstanceTransform = InstanceGameObject.transform.parent;
-			Camera InstanceCamera = null;
-			while(null != InstanceTransform)
-			{
-				InstanceCamera = InstanceTransform.camera;
-				if(null != InstanceCamera)
-				{
-					break;
-				}
-				InstanceTransform = InstanceTransform.parent;
-			}
-			return(InstanceCamera);
-		}
-
 		public static Script_SpriteStudio_DrawManagerView DrawManagerViewGetParent(GameObject InstanceGameObject)
 		{
 			Transform InstanceTransform = InstanceGameObject.transform.parent;
@@ -1038,7 +1022,7 @@ public static partial class Library_SpriteStudio
 				return;
 			}
 
-			public void MeshSetCombine(MeshFilter InstanceMeshFilter, MeshRenderer InstanceMeshRenderer, Camera InstanceCamera, Transform InstanceTransform)
+			public void MeshSetCombine(MeshFilter InstanceMeshFilter, MeshRenderer InstanceMeshRenderer, Transform InstanceTransform)
 			{
 				if(null != tableListMesh)
 				{


### PR DESCRIPTION
- Root0
  - Instance1
    - Root1
      - Instance2
        - Root2

のような構造にしたとき、以下のような処理準となり孫以降のInstanceのアニメーション再生は1フレームずつ遅れる問題がある。
- 1Frame目でRoot0でREDECODE_INSTANCEが立った時
- 1Frame中にInstance1のUpdateInstanceDataでRoot1のAnimationPlayが呼ばれる（子はアニメーション遅れない）
- 2Frame目でRoo1のUpdateの中でREDECODE_INSTANCEが立つ
- 2Frame中にInstance2のUpdateInstanceDataでRoot2のAnimationPlayが呼ばれる（孫はアニメーションが1フレーム遅れる）

