### PR TITLE
インポート時に透明ピクセルをトリミングするオプション追加

### DIFF
--- a/Assets/SpriteStudio/Editor/MenuItem_SpriteStudio.cs
+++ b/Assets/SpriteStudio/Editor/MenuItem_SpriteStudio.cs
@@ -21,6 +21,8 @@ public sealed class MenuItem_SpriteStudio : EditorWindow
 	private static bool FlagDataCalculateInAdvance = true;
 	private static bool FlagDataCompress = true;
 	private static bool FlagDataTakeOverSettingPrefab = false;
+	private static bool FlagDataCellTrimTransparentPixels = false;
+
 	private static float CollisionThicknessZ = 1.0f;
 	private static bool FlagAttachRigidBody = false;
 	private static bool FlagConfirmOverWrite = false;
@@ -97,6 +99,9 @@ public sealed class MenuItem_SpriteStudio : EditorWindow
 			FlagDataTakeOverSettingPrefab = EditorGUILayout.Toggle("Take over setting", FlagDataTakeOverSettingPrefab);
 			EditorGUILayout.LabelField(" Takes over the setting of \"Script_SpriteStudio_Root\"");
 			EditorGUILayout.LabelField("   and \"Script_SpriteStudio_RootEffect\" in Prefabs.");
+			EditorGUILayout.Space();
+
+			FlagDataCellTrimTransparentPixels = EditorGUILayout.Toggle("Trim transparent pixels", FlagDataCellTrimTransparentPixels);
 			EditorGUILayout.Space();
 
 			EditorGUI.indentLevel = LevelIndent;
@@ -374,6 +379,7 @@ public sealed class MenuItem_SpriteStudio : EditorWindow
 			SettingImport.FlagDataCalculateInAdvance = FlagDataCalculateInAdvance;
 			SettingImport.FlagDataCompress = FlagDataCompress;
 			SettingImport.FlagDataTakeOverSettingPrefab = FlagDataTakeOverSettingPrefab;
+			SettingImport.FlagDataCellTrimTransparentPixels = FlagDataCellTrimTransparentPixels;
 
 			SettingImport.CollisionThicknessZ = CollisionThicknessZ;
 			SettingImport.FlagAttachRigidBody = FlagAttachRigidBody;


### PR DESCRIPTION
　sspjインポートのオプションに`Trim transparent pixels`を追加します。

　オプションを有効にすることで、セルに含まれる透明な領域をトリミングします。これによって余分な描画範囲を減らすことができます。描画範囲はsceneビューのOverdraw表示等で確認できます。

　セルのサイズを変更するので、頂点カラーやUV移動を指定している場合、影響を受けて表示が変わってしまいます。そのため、デフォルトではオプションは無効にしています。
