### PR TITLE
カラーブレンド指定が無視される不具合を修正

### DIFF
--- a/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
+++ b/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
@@ -2515,7 +2515,7 @@ public static partial class Library_SpriteStudio
 				if (updateColorAlways || DataPartsDrawManager.DrawParts.Data.CurrentMeshColor != nextColor)
 				{
 					DataPartsDrawManager.DrawParts.Data.CurrentMeshColor = nextColor;
-					InstanceMesh.colors32 = InstanceParameterMesh.ColorOverlay;
+					InstanceMesh.colors32 = nextColor;
 				}
 //				InstanceMesh.RecalculateBounds();
 


### PR DESCRIPTION
　SpriteStudioで設定したカラーブレンドが正常に反映されない不具合の修正です。
　不具合は先日のPRで発生したものとなります。ご迷惑をおかけして申し訳ありません。

