### PR TITLE
ManagerDrawのlocalToWorldMatrixが単位行列のとき高速化

### DIFF
--- a/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
+++ b/Assets/SpriteStudio/ScriptLibrary/Library_SpriteStudio.cs
@@ -5101,7 +5101,18 @@ public static partial class Library_SpriteStudio
 			}
 
 			/* Create Combined Mesh */
-			Matrix4x4 MatrixCollect = (null != InstanceTrasnformDrawManager) ? InstanceTrasnformDrawManager.localToWorldMatrix.inverse : Matrix4x4.identity;
+			Matrix4x4 MatrixCollect;
+			bool MatrixCollectIsIdentity;
+			if(null != InstanceTrasnformDrawManager)
+			{
+				MatrixCollect = InstanceTrasnformDrawManager.localToWorldMatrix.inverse;
+				MatrixCollectIsIdentity = MatrixCollect.isIdentity;
+			}
+			else
+			{
+				MatrixCollect = Matrix4x4.identity;
+				MatrixCollectIsIdentity = true;
+			}
 
 			if((null == CombineMesh) || (CombineMesh.Length != CountMesh))
 			{
@@ -5153,7 +5164,14 @@ public static partial class Library_SpriteStudio
 					if(null != DataPartsNow.Data.InstanceMesh)
 					{
 						CombineMesh[Index].mesh = DataPartsNow.Data.InstanceMesh;
-						CombineMesh[Index].transform = MatrixCollect * DataPartsNow.Data.InstanceTransform.localToWorldMatrix;
+						if(MatrixCollectIsIdentity)
+						{
+							CombineMesh[Index].transform = DataPartsNow.Data.InstanceTransform.localToWorldMatrix;
+						}
+						else
+						{
+							CombineMesh[Index].transform = MatrixCollect * DataPartsNow.Data.InstanceTransform.localToWorldMatrix;
+						}
 						Index++;
 						IndexTriangle += (KindParts.NORMAL_TRIANGLE4 == DataPartsNow.Data.Kind) ? 4 : 2;    /* ArrayCoordinate_TriangleX.Length / 3 */
 					}


### PR DESCRIPTION
　ManagerDrawのlocalToWorldMatrixが単位行列を返す時、MeshCreateメソッド内で行われる行列計算を軽量化することができます。

　条件を満たさない場合はMatrix4x4.isIdentityの呼び出し処理が無駄に走ることになりますが、isIdendtityプロパティは十分軽いと判断しています。
